### PR TITLE
Fluid 6472: Remove gpii namespace and fix piano controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ RTIMULib.ini
 
 # package lock file
 package-lock.json
+
+# VSCode configuration
+.vscode/

--- a/music-demo/bonang-synth-control/js/nexusBonangSynthControl.js
+++ b/music-demo/bonang-synth-control/js/nexusBonangSynthControl.js
@@ -2,7 +2,7 @@
     "use strict";
 
     fluid.defaults("fluid.nexusBonangSynthControl", {
-        gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
+        gradeNames: ["fluid.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         selectors: {
             noteInput: ".fluidc-bonang-synth-note",
             sendButton: ".fluidc-bonang-synth-send"

--- a/music-demo/bonang-synth/js/nexusBonangSynth.js
+++ b/music-demo/bonang-synth/js/nexusBonangSynth.js
@@ -2,7 +2,7 @@
     "use strict";
 
     fluid.defaults("fluid.nexusBonangSynth", {
-        gradeNames: "gpii.nexusWebSocketBoundComponent",
+        gradeNames: "fluid.nexusWebSocketBoundComponent",
         members: {
             nexusPeerComponentPath: "nexus.bonang.synth",
             nexusBoundModelPath: "controls",

--- a/music-demo/constructNexusPeers.js
+++ b/music-demo/constructNexusPeers.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var fluid = require("infusion");
-var gpii = fluid.registerNamespace("gpii");
 
 require("infusion-nexus-client");
 
@@ -22,12 +21,12 @@ var joystickQuantizeSteps = 16; // Number of notes = joystickQuantizeSteps / 2 (
 
 fluid.promise.sequence([
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus", {
             type: "fluid.modelComponent"
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.asterics", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.asterics", {
             type: "fluid.modelComponent",
             model: {
                 connector: {
@@ -73,12 +72,12 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang", {
             type: "fluid.modelComponent"
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.control", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.control", {
             type: "fluid.modelComponent",
             model: {
                 activeNote: -1
@@ -86,7 +85,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.zoneController", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.zoneController", {
             type: "fluid.modelComponent",
             model: {
                 activeZoneIdx: -1
@@ -94,7 +93,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.pianoController", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.pianoController", {
             type: "fluid.modelComponent",
             model: {
                 activeNote: -1
@@ -102,7 +101,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.sensors", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.sensors", {
             type: "fluid.modelComponent",
             model: {
                 orientation: { }
@@ -117,7 +116,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.synth", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.bonang.synth", {
             type: "fluid.modelComponent",
             modelRelay: [
                 {
@@ -225,7 +224,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "nexus.brailleDisplay", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "nexus.brailleDisplay", {
             type: "fluid.modelComponent",
             model: {
                 displayText: ""

--- a/music-demo/device-orientation/js/nexusOrientationSensor.js
+++ b/music-demo/device-orientation/js/nexusOrientationSensor.js
@@ -4,7 +4,7 @@
     "use strict";
 
     fluid.defaults("fluid.nexusOrientationSensor", {
-        gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
+        gradeNames: ["fluid.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         selectors: {
             displayOrientationValues: ".fluidc-display-orientation-values"
         },

--- a/music-demo/piano-controller/js/pianoController.js
+++ b/music-demo/piano-controller/js/pianoController.js
@@ -111,7 +111,7 @@
     });
 
     fluid.defaults("fluid.nexusPianoController", {
-        gradeNames: ["gpii.nexusWebSocketBoundComponent", "flock.ui.modelKeyboard"],
+        gradeNames: ["fluid.nexusWebSocketBoundComponent", "flock.ui.modelKeyboard"],
 
         highlightKeys: [
             "C6",

--- a/music-demo/piano-controller/js/pianoController.js
+++ b/music-demo/piano-controller/js/pianoController.js
@@ -147,7 +147,7 @@
 
     fluid.nexusPianoController.highlightKeys = function (container, options) {
         fluid.each(options.highlightKeys, function (key) {
-            container.find("[id=" + key + "]").addClass(options.styles.highlightedKey);
+            container.find("[id='" + key + "']").addClass(options.styles.highlightedKey);
         });
     };
 }());

--- a/music-demo/zone-controller/js/head-tracker-synth.js
+++ b/music-demo/zone-controller/js/head-tracker-synth.js
@@ -63,6 +63,10 @@
         gradeNames: "fluid.viewComponent",
 
         model: {
+            /* TODO: likely due to Infusion bugs related to model initialization, these expanders do not work as intended
+               both height and width end up set to 0.
+               Since flocking is currently incompatible with the dev release that fixes these issues, the below onCreate
+               listener manually sets the model values.
             height: {
                 expander: {
                     "this": "{that}.container",
@@ -76,6 +80,42 @@
                     method: "width"
                 }
             }
+            */
+           // FIXME: I don't even know why these work
+           // no one is currently generating the actual page bounds, so I'm not sure how the pointer continues to function
+           height: 1,
+           width: 1
         }
+
+        // TODO: this listener should be unnecessary once we move to a post-FLUID-6145 Infusion release
+        // listeners: {
+        //     "onCreate.setRegionBounds": "fluid.trackerSynth.trackingRegion.setRegionBounds({that})"
+        // },
+
+        // Debugging, delete later
+        // modelListeners: {
+        //     height: {
+        //         funcName: "fluid.trackerSynth.trackingRegion.listenToBounds",
+        //         args: "{change}.value"
+        //     }
+        // }
     });
+
+    // TODO: remove
+//     fluid.trackerSynth.trackingRegion.setRegionBounds = function(trackingRegion) {
+//         console.log(trackingRegion.model);
+//         trackingRegion.applier.change("height", trackingRegion.container.height());
+//         trackingRegion.applier.change("width", trackingRegion.container.width());
+//         console.log(trackingRegion.model);
+//     };
+
+    // TODO: remove
+//     fluid.trackerSynth.trackingRegion.listenToBounds = function(height) {
+//         if (height === 0) {
+//             console.log('height set to 0');
+//             // throw new Error('height set to 0');
+//         } else {
+//             console.log('height set to non-zero value');
+//         }
+//     };
 }());

--- a/music-demo/zone-controller/js/mouse-pointer.js
+++ b/music-demo/zone-controller/js/mouse-pointer.js
@@ -17,10 +17,13 @@
                 }
             },
 
-            bounds: {
-                width: 0,
-                height: 0
-            }
+            // TODO: due to Infusion model transformation bugs, this default ends up overwriting the trackingRegion's bounds,
+            //        even though it should be the canonical source. This is due to the model relays below, combined with the
+            //        options fed into the pointer in nexusZoneController.js
+            // bounds: {
+            //     width: 0,
+            //     height: 0
+            // }
         },
 
         modelRelay: [

--- a/music-demo/zone-controller/js/mouse-tracker.js
+++ b/music-demo/zone-controller/js/mouse-tracker.js
@@ -11,10 +11,13 @@
                 y: 0
             },
 
-            bounds: {
-                height: 1,
-                width: 1
-            }
+            // TODO: due to Infusion model transformation bugs, this default ends up overwriting the trackingRegion's bounds,
+            //        even though it should be the canonical source. This is due to the model relays below, combined with the
+            //        options fed into the pointer in nexusZoneController.js
+            // bounds: {
+            //     width: 0,
+            //     height: 0
+            // }
         },
 
         axisMap: {

--- a/music-demo/zone-controller/js/nexusZoneController.js
+++ b/music-demo/zone-controller/js/nexusZoneController.js
@@ -2,7 +2,7 @@
     "use strict";
 
     fluid.defaults("fluid.nexusZoneController", {
-        gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
+        gradeNames: ["fluid.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         members: {
             nexusPeerComponentPath: "nexus.bonang.zoneController",
             nexusBoundModelPath: "activeZoneIdx",

--- a/science-lab/ConstructScienceLabPeersAndRecipes.js
+++ b/science-lab/ConstructScienceLabPeersAndRecipes.js
@@ -10,7 +10,7 @@ var nexusPort = 9081;
 
 fluid.promise.sequence([
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.fakeSensor",
@@ -23,7 +23,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.fakeSensorPH",
@@ -36,7 +36,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.fakeSensorTemperature",
@@ -49,7 +49,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.atlasScientificDriver.phSensor",
@@ -62,7 +62,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.atlasScientificDriver.ecSensor",
@@ -75,7 +75,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.rpiSenseHatDriver.tempSensor1",
@@ -88,7 +88,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.rpiSenseHatDriver.tempSensor2",
@@ -101,7 +101,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.collector",
@@ -114,7 +114,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.sendFakeSensor",
@@ -148,7 +148,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.sendfakeSensorPH",
@@ -182,7 +182,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.sendfakeSensorTemperature",
@@ -216,7 +216,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.sendPhSensor",
@@ -250,7 +250,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.sendEcSensor",
@@ -284,7 +284,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.sendRpiTempSensor1",
@@ -318,7 +318,7 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.writeNexusDefaults(
+        return fluid.writeNexusDefaults(
             nexusHost,
             nexusPort,
             "fluid.nexus.scienceLab.sendRpiTempSensor2",
@@ -352,12 +352,12 @@ fluid.promise.sequence([
         );
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "scienceLabCollector", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "scienceLabCollector", {
             type: "fluid.nexus.scienceLab.collector"
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendFakeSensor", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "recipes.sendFakeSensor", {
             type: "fluid.nexus.recipe",
             reactants: {
                 fakeSensor: {
@@ -382,7 +382,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendfakeSensorPH", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "recipes.sendfakeSensorPH", {
             type: "fluid.nexus.recipe",
             reactants: {
                 fakeSensorPH: {
@@ -407,7 +407,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendfakeSensorTemperature", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "recipes.sendfakeSensorTemperature", {
             type: "fluid.nexus.recipe",
             reactants: {
                 fakeSensorTemperature: {
@@ -432,7 +432,7 @@ fluid.promise.sequence([
         });
     },    
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendPhSensor", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "recipes.sendPhSensor", {
             type: "fluid.nexus.recipe",
             reactants: {
                 phSensor: {
@@ -457,7 +457,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendEcSensor", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "recipes.sendEcSensor", {
             type: "fluid.nexus.recipe",
             reactants: {
                 ecSensor: {
@@ -482,7 +482,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendRpiTempSensor1", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "recipes.sendRpiTempSensor1", {
             type: "fluid.nexus.recipe",
             reactants: {
                 tempSensor: {
@@ -507,7 +507,7 @@ fluid.promise.sequence([
         });
     },
     function () {
-        return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendRpiTempSensor2", {
+        return fluid.constructNexusPeer(nexusHost, nexusPort, "recipes.sendRpiTempSensor2", {
             type: "fluid.nexus.recipe",
             reactants: {
                 tempSensor: {

--- a/science-lab/FakeSensor.js
+++ b/science-lab/FakeSensor.js
@@ -8,7 +8,7 @@ var nexusHost = "localhost";
 var nexusPort = 9081;
 
 fluid.defaults("fluid.nexus.fakeSensor", {
-    gradeNames: ["gpii.nexusWebSocketBoundComponent"],
+    gradeNames: ["fluid.nexusWebSocketBoundComponent"],
     model: {
         fakeSensorConfig: {
             updateDelayMs: 1000

--- a/science-lab/atlas-scientific-driver/AtlasScientificDriver.js
+++ b/science-lab/atlas-scientific-driver/AtlasScientificDriver.js
@@ -176,7 +176,7 @@ fluid.defaults("fluid.nexus.atlasScientificDriver", {
         },
 
         nexusBinding: {
-            type: "gpii.nexusWebSocketBoundComponent",
+            type: "fluid.nexusWebSocketBoundComponent",
             createOnEvent: "{atlasScientificConnection}.events.onDeviceInformation",
             options: {
                 circuitType: "{arguments}.0.deviceType",

--- a/science-lab/dashboard/js/NexusScienceLabDashboard.js
+++ b/science-lab/dashboard/js/NexusScienceLabDashboard.js
@@ -4,7 +4,7 @@
     // TODO: Add ARIA live region markup?
 
     fluid.defaults("fluid.nexusScienceLabDashboard", {
-        gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
+        gradeNames: ["fluid.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         numberLocale: "en",
         maximumFractionDigits: 2,
         members: {

--- a/science-lab/rpi-sense-hat-driver/RpiSenseHatDriver.js
+++ b/science-lab/rpi-sense-hat-driver/RpiSenseHatDriver.js
@@ -69,7 +69,7 @@ fluid.defaults("fluid.nexus.rpiSenseHatDriver", {
             }
         },
         tempNexusBinding: {
-            type: "gpii.nexusWebSocketBoundComponent",
+            type: "fluid.nexusWebSocketBoundComponent",
             options: {
                 members: {
                     nexusHost: "{rpiSenseHatDriver}.options.nexusHost",

--- a/science-lab/sensor-presentations/js/nexusSensorPresentationPanel.js
+++ b/science-lab/sensor-presentations/js/nexusSensorPresentationPanel.js
@@ -5,7 +5,7 @@
     // An implementing grade needs to supply
     // appropriate dynamic components
     fluid.defaults("fluid.nexusSensorPresentationPanel", {
-        gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
+        gradeNames: ["fluid.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         events: {
             onSensorAppearance: null,
             onSensorRemoval: null

--- a/science-lab/sensor-presentations/tests/js/mocks.js
+++ b/science-lab/sensor-presentations/tests/js/mocks.js
@@ -9,14 +9,14 @@
     // appropriate model path intended to be attached via the
     // nexusBoundModelPath member
 
-    fluid.defaults("gpii.nexusWebSocketBoundComponentMock", {
-        gradeNames: ["gpii.nexusWebSocketBoundComponent"],
+    fluid.defaults("fluid.nexusWebSocketBoundComponentMock", {
+        gradeNames: ["fluid.nexusWebSocketBoundComponent"],
         listeners: {
             "onCreate.constructPeer": {
                 funcName: "{that}.events.onPeerConstructed.fire"
             },
             "onPeerConstructed.bindNexusModel": {
-                funcName: "gpii.nexusWebSocketBoundComponentMock.bindModel",
+                funcName: "fluid.nexusWebSocketBoundComponentMock.bindModel",
                 args: [
                     "{that}",
                     "{that}.receivesChangesFromNexus",
@@ -25,7 +25,7 @@
                 ]
             },
             "onWebsocketConnected.registerModelListenerForNexus": {
-                funcName: "gpii.nexusWebSocketBoundComponentMock.registerModelListener",
+                funcName: "fluid.nexusWebSocketBoundComponentMock.registerModelListener",
                 args: [
                     "{that}.sendsChangesToNexus",
                     "{that}.applier",
@@ -37,16 +37,16 @@
     }
 );
 
-gpii.nexusWebSocketBoundComponentMock.bindModel = function () {
+fluid.nexusWebSocketBoundComponentMock.bindModel = function () {
     return;
 };
 
-gpii.nexusWebSocketBoundComponentMock.registerModelListener = function () {
+fluid.nexusWebSocketBoundComponentMock.registerModelListener = function () {
     return;
 };
 
     fluid.defaults("fluid.nexusSensorPresentationPanelMock", {
-        gradeNames: ["fluid.nexusSensorPresentationPanel", "gpii.nexusWebSocketBoundComponentMock", "fluid.viewComponent"],
+        gradeNames: ["fluid.nexusSensorPresentationPanel", "fluid.nexusWebSocketBoundComponentMock", "fluid.viewComponent"],
         // Eases testing, since we don't have to pause to wait for
         // the fade-out animation before testing that the container
         // is removed


### PR DESCRIPTION
I have changed all uses of the "gpii" namespace to "fluid" and fixed an issue where the piano controller breaks because we try to find an element using the CSS selector "[id=A#6]" by escaping the id with quotes.

Several things are still broken, but I figure it's worth collecting work in this branch as it happens.